### PR TITLE
Remove snippet config for 'self'

### DIFF
--- a/snippets/language-renpy.cson
+++ b/snippets/language-renpy.cson
@@ -361,9 +361,3 @@
     prefix: 'ww'
     body: '{w=${1:wait time}}'
     leftLabelHTML: '<span title="Text tag" class="renpy-snippet renpy-texttag">T</span>'
-
-
-'.source.renpy:not(.string)':
-  'self':
-    prefix: '.'
-    body: 'self.'


### PR DESCRIPTION
The benefit of this is outweighed by it interfering with the regular use of the '.' character.
It has already been removed from language-python, for similar reasons.

for example:

![self](https://user-images.githubusercontent.com/14958747/70176422-5d25fa00-16d0-11ea-90d2-00b16a35521b.png)